### PR TITLE
Missing Int for latest bind9

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,5 @@
 Adam Tkac <atkac@redhat.com>
+Dan Molik <dan@danmolik.com>
 David Kupka <dkupka@redhat.com>
 Jiri Kuncar <jkuncar@redhat.com>
 Lukas Slebodnik <lslebodn@redhat.com>

--- a/src/types.h
+++ b/src/types.h
@@ -1,10 +1,11 @@
 /*
- * Copyright (C) 2011-2013  bind-dyndb-ldap authors; see COPYING for license
+ * Copyright (C) 2011-2019  bind-dyndb-ldap authors; see COPYING for license
  */
 
 #ifndef _LD_TYPES_H_
 #define _LD_TYPES_H_
 
+#include <isc/int.h>
 #include <isc/event.h>
 #include <isc/refcount.h>
 #include <dns/name.h>

--- a/src/zone.c
+++ b/src/zone.c
@@ -1,7 +1,8 @@
 /*
- * Copyright (C) 2014-2015  bind-dyndb-ldap authors; see COPYING for license
+ * Copyright (C) 2014-2019  bind-dyndb-ldap authors; see COPYING for license
  */
 
+#include <isc/int.h>
 #include <isc/types.h>
 #include <isc/util.h>
 


### PR DESCRIPTION
I had to make an adjustment to get it to compile with 9.12.3_p1 I figure you might find it useful